### PR TITLE
Remapeio de chaves do hash

### DIFF
--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -19,6 +19,10 @@ class Hash
   end
 
   def remap_keys(remap)
+    dup.remap_keys!(remap)
+  end
+
+  def remap_keys!(remap)
     tap do |hash|
       remap.each do |o, n|
         hash[n] = hash.delete o

--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -23,11 +23,11 @@ class Hash
   end
 
   def remap_keys!(remap)
-    tap do |hash|
-      remap.each do |o, n|
-        hash[n] = hash.delete o
-      end
+    new_hash = {}
+    remap.each do |o, n|
+      new_hash[n] = delete o
     end
+    merge! new_hash
   end
 
   def lower_camelize_keys(options = {})

--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -19,8 +19,10 @@ class Hash
   end
 
   def remap_keys(remap)
-    change_keys do |key|
-      remap.key?(key) ? remap[key] : key
+    tap do |hash|
+      remap.each do |o, n|
+        hash[n] = hash.delete o
+      end
     end
   end
 

--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -18,6 +18,12 @@ class Hash
     end
   end
 
+  def remap_keys(remap)
+    change_keys do |key|
+      remap.key?(key) ? remap[key] : key
+    end
+  end
+
   def lower_camelize_keys(options = {})
     dup.lower_camelize_keys!(options)
   end

--- a/spec/lib/hash_spec.rb
+++ b/spec/lib/hash_spec.rb
@@ -24,6 +24,35 @@ describe Hash do
     end
   end
 
+  describe :remap_keys do
+    let(:subject) { { a: 1, b: 2 } }
+    let(:result) { subject.remap_keys(remap) }
+
+    context 'when remap and hash keys match' do
+      let(:remap) { { a: :e, b: :f } }
+
+      it 'remaps the keys' do
+        expect(result).to eq(e: 1, f: 2)
+      end
+    end
+
+    context 'when remap and hash keys do not match' do
+      let(:remap) { { b: :f } }
+
+      it 'remap oinly the keys that match' do
+        expect(result).to eq(a: 1, f: 2)
+      end
+    end
+
+    context 'when remap has no keys' do
+      let(:remap) { {} }
+
+      it 'does not remap the keys' do
+        expect(result).to eq(a: 1, b: 2)
+      end
+    end
+  end
+
   describe :sort_keys do
     it 'sorts keys as symbols' do
       { b: 1, a: 2 }.sort_keys.should eq(a: 2, b: 1)

--- a/spec/lib/hash_spec.rb
+++ b/spec/lib/hash_spec.rb
@@ -39,8 +39,16 @@ describe Hash do
     context 'when remap and hash keys do not match' do
       let(:remap) { { b: :f } }
 
-      it 'remap oinly the keys that match' do
+      it 'remap only the keys that match' do
         expect(result).to eq(a: 1, f: 2)
+      end
+    end
+
+    context 'when there are keys out of the keys list' do
+      let(:remap) { { c: :g } }
+
+      it 'creates a nil valued key' do
+        expect(result).to eq(a: 1, b: 2, g: nil)
       end
     end
 

--- a/spec/lib/hash_spec.rb
+++ b/spec/lib/hash_spec.rb
@@ -5,6 +5,7 @@ describe Hash do
   it_behaves_like 'a class with camlize_keys method'
   it_behaves_like 'a class with append_keys method'
   it_behaves_like 'a class with change_kvalues method'
+  it_behaves_like 'a class with remap method'
 
   describe :squash do
     let(:hash) { { a: { b: 1, c: { d: 2 } } } }

--- a/spec/lib/hash_spec.rb
+++ b/spec/lib/hash_spec.rb
@@ -24,43 +24,6 @@ describe Hash do
     end
   end
 
-  describe :remap_keys do
-    let(:subject) { { a: 1, b: 2 } }
-    let(:result) { subject.remap_keys(remap) }
-
-    context 'when remap and hash keys match' do
-      let(:remap) { { a: :e, b: :f } }
-
-      it 'remaps the keys' do
-        expect(result).to eq(e: 1, f: 2)
-      end
-    end
-
-    context 'when remap and hash keys do not match' do
-      let(:remap) { { b: :f } }
-
-      it 'remap only the keys that match' do
-        expect(result).to eq(a: 1, f: 2)
-      end
-    end
-
-    context 'when there are keys out of the keys list' do
-      let(:remap) { { c: :g } }
-
-      it 'creates a nil valued key' do
-        expect(result).to eq(a: 1, b: 2, g: nil)
-      end
-    end
-
-    context 'when remap has no keys' do
-      let(:remap) { {} }
-
-      it 'does not remap the keys' do
-        expect(result).to eq(a: 1, b: 2)
-      end
-    end
-  end
-
   describe :sort_keys do
     it 'sorts keys as symbols' do
       { b: 1, a: 2 }.sort_keys.should eq(a: 2, b: 1)

--- a/spec/support/shared_examples/remap.rb
+++ b/spec/support/shared_examples/remap.rb
@@ -53,4 +53,20 @@ shared_examples 'a method that remaps the keys' do |method|
       expect(result).to eq(a: 1, b: 2)
     end
   end
+
+  context 'when remap has original array keys' do
+    let(:remap) { { b: :a, a: :b } }
+
+    it 'does not remap the keys' do
+      expect(result).to eq(b: 1, a: 2)
+    end
+  end
+
+  context 'when remap has original array keys' do
+    let(:remap) { { a: :b, b: :c } }
+
+    it 'does not remap the keys' do
+      expect(result).to eq(b: 1, c: 2)
+    end
+  end
 end

--- a/spec/support/shared_examples/remap.rb
+++ b/spec/support/shared_examples/remap.rb
@@ -1,0 +1,38 @@
+shared_examples 'a class with remap method' do
+  describe :remap_keys do
+    let(:subject) { { a: 1, b: 2 } }
+    let(:result) { subject.remap_keys(remap) }
+
+    context 'when remap and hash keys match' do
+      let(:remap) { { a: :e, b: :f } }
+
+      it 'remaps the keys' do
+        expect(result).to eq(e: 1, f: 2)
+      end
+    end
+
+    context 'when remap and hash keys do not match' do
+      let(:remap) { { b: :f } }
+
+      it 'remap only the keys that match' do
+        expect(result).to eq(a: 1, f: 2)
+      end
+    end
+
+    context 'when there are keys out of the keys list' do
+      let(:remap) { { c: :g } }
+
+      it 'creates a nil valued key' do
+        expect(result).to eq(a: 1, b: 2, g: nil)
+      end
+    end
+
+    context 'when remap has no keys' do
+      let(:remap) { {} }
+
+      it 'does not remap the keys' do
+        expect(result).to eq(a: 1, b: 2)
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/remap.rb
+++ b/spec/support/shared_examples/remap.rb
@@ -69,4 +69,21 @@ shared_examples 'a method that remaps the keys' do |method|
       expect(result).to eq(b: 1, c: 2)
     end
   end
+
+  context 'when changing the type of the key' do
+    let(:remap) { { a: 'a' } }
+
+    it 'does not remap the keys' do
+      expect(result).to eq('a' => 1, b: 2)
+    end
+
+    context 'and the original key is an string' do
+      let(:subject) { { 'a' => 1, 'b' => 2 } }
+      let(:remap) { { 'a' => :a } }
+
+      it 'does not remap the keys' do
+        expect(result).to eq(a: 1, 'b' => 2)
+      end
+    end
+  end
 end

--- a/spec/support/shared_examples/remap.rb
+++ b/spec/support/shared_examples/remap.rb
@@ -1,38 +1,56 @@
 shared_examples 'a class with remap method' do
+  let(:subject) { { a: 1, b: 2 } }
+
   describe :remap_keys do
-    let(:subject) { { a: 1, b: 2 } }
-    let(:result) { subject.remap_keys(remap) }
+    it_behaves_like 'a method that remaps the keys', :remap_keys
 
-    context 'when remap and hash keys match' do
-      let(:remap) { { a: :e, b: :f } }
-
-      it 'remaps the keys' do
-        expect(result).to eq(e: 1, f: 2)
-      end
+    it 'does not change the original hash' do
+      expect { subject.remap_keys(a: :e) }.not_to change { subject }
     end
+  end
 
-    context 'when remap and hash keys do not match' do
-      let(:remap) { { b: :f } }
+  describe :remap_keys! do
+    it_behaves_like 'a method that remaps the keys', :remap_keys!
 
-      it 'remap only the keys that match' do
-        expect(result).to eq(a: 1, f: 2)
-      end
+    it 'changes the original hash' do
+      expect { subject.remap_keys!(a: :e) }.to change { subject }
     end
+  end
 
-    context 'when there are keys out of the keys list' do
-      let(:remap) { { c: :g } }
+end
 
-      it 'creates a nil valued key' do
-        expect(result).to eq(a: 1, b: 2, g: nil)
-      end
+shared_examples 'a method that remaps the keys' do |method|
+  let(:result) { subject.public_send(method, remap) }
+
+  context 'when remap and hash keys match' do
+    let(:remap) { { a: :e, b: :f } }
+
+    it 'remaps the keys' do
+      expect(result).to eq(e: 1, f: 2)
     end
+  end
 
-    context 'when remap has no keys' do
-      let(:remap) { {} }
+  context 'when remap and hash keys do not match' do
+    let(:remap) { { b: :f } }
 
-      it 'does not remap the keys' do
-        expect(result).to eq(a: 1, b: 2)
-      end
+    it 'remap only the keys that match' do
+      expect(result).to eq(a: 1, f: 2)
+    end
+  end
+
+  context 'when there are keys out of the keys list' do
+    let(:remap) { { c: :g } }
+
+    it 'creates a nil valued key' do
+      expect(result).to eq(a: 1, b: 2, g: nil)
+    end
+  end
+
+  context 'when remap has no keys' do
+    let(:remap) { {} }
+
+    it 'does not remap the keys' do
+      expect(result).to eq(a: 1, b: 2)
     end
   end
 end


### PR DESCRIPTION
This PR creates a method to remap the keys of a hash

```ruby
{ a:1, b: 2 }.remap_keys(a: :e, c: :g)
{ e: 1, b: 2, g: nil }
```