### PR TITLE
Exclusive merge

### DIFF
--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -36,6 +36,14 @@ class Hash
     Hash::KeyChanger.new(self).camelize_keys(options)
   end
 
+  def exclusive_merge(hash)
+    dup.exclusive_merge!(hash)
+  end
+
+  def exclusive_merge!(hash)
+    merge!(hash.slice(*keys))
+  end
+
   # change all keys returning the new map
   # options: { recursive: true }
   # ex: { "a":1 }.change_keys{ |key| key.upcase } == { "A":1 }

--- a/spec/lib/hash_spec.rb
+++ b/spec/lib/hash_spec.rb
@@ -52,6 +52,32 @@ describe Hash do
     end
   end
 
+  describe :exclusive_merge do
+    let(:subject) { { a: 1, b: 2 } }
+    let(:other) { { b: 3, c: 4 } }
+
+    it 'merge only the common keys' do
+      expect(subject.exclusive_merge(other)).to eq(a: 1, b: 3)
+    end
+
+    it 'does not change the original hash' do
+      expect { subject.exclusive_merge(other) }.not_to change { subject }
+    end
+  end
+
+  describe :exclusive_merge! do
+    let(:subject) { { a: 1, b: 2 } }
+    let(:other) { { b: 3, c: 4 } }
+
+    it 'merge only the common keys' do
+      expect(subject.exclusive_merge!(other)).to eq(a: 1, b: 3)
+    end
+
+    it 'does not change the original hash' do
+      expect { subject.exclusive_merge!(other) }.to change { subject }
+    end
+  end
+
   describe :to_deep_hash do
     let(:subject) do
       {


### PR DESCRIPTION
This PR adds the exclusive merge

```ruby
{ a: 1, b: 2 }.exclusive_merge(b: 3, c: 4)
{ a: 1, b: 3 }
```