### PR TITLE
Chain map method

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@ Core_Ext
 This project adds some new methods to the core ruby classes
 
 ## Array
+### chain_map
+applies map in a chain
+
+```ruby
+array = [ :a, :long_name, :sym ]
+array.chain_map(:to_s, :size, :to_s)
+[ '1', '9', '3' ]
+```
+
+```ruby
+array = [ :a, :long_name, :sym ]
+array.chain_map(:to_s, :size) { |v| "final: #{v}" }
+[ 'final: 1', 'final: 9', 'final: 3' ]
+```
+
 ### as_hash
 Creates a hash from the array using the argumen array as keys
 

--- a/lib/array.rb
+++ b/lib/array.rb
@@ -4,7 +4,9 @@ class Array
   def chain_map(*methods)
     result = self
     result = result.map(&(methods.shift)) until methods.empty?
-    result
+    
+    return result unless block_given?
+    result.map { |*args| yield(*args) }
   end
 
   def as_hash(keys)

--- a/lib/array.rb
+++ b/lib/array.rb
@@ -1,6 +1,9 @@
 require 'array/hash_builder'
 
 class Array
+  def chain_map(*methods)
+  end
+
   def as_hash(keys)
     Array::HashBuilder.new(self, keys).build
   end

--- a/lib/array.rb
+++ b/lib/array.rb
@@ -2,6 +2,9 @@ require 'array/hash_builder'
 
 class Array
   def chain_map(*methods)
+    result = self
+    result = result.map(&(methods.shift)) until methods.empty?
+    result
   end
 
   def as_hash(keys)

--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -6,9 +6,6 @@ class Hash
   def chain_fetch(*keys)
   end
 
-  def chain_map(*methods)
-  end
-
   def squash
     {}.tap do |hash|
       each do |key, value|

--- a/spec/lib/array_spec.rb
+++ b/spec/lib/array_spec.rb
@@ -2,6 +2,12 @@ require 'spec_helper'
 
 describe Array do
   describe '#chain_map' do
+    let(:array) { [ :a, :long_name, :sym ] }
+    let(:mapped) { array.chain_map(:to_s, :size, :to_s) }
+
+    it 'calls each argument as method of the mapped result' do
+      expect(mapped).to eq([ '1', '9', '3' ])
+    end
   end
 
   describe '#as_hash' do

--- a/spec/lib/array_spec.rb
+++ b/spec/lib/array_spec.rb
@@ -8,6 +8,18 @@ describe Array do
     it 'calls each argument as method of the mapped result' do
       expect(mapped).to eq([ '1', '9', '3' ])
     end
+
+    context 'when an extra block is given' do
+      let(:mapped) do
+        array.chain_map(:to_s, :size) do |v|
+          "final: #{v}"
+        end
+      end
+
+      it 'calls each argument as method of the mapped result' do
+        expect(mapped).to eq([ 'final: 1', 'final: 9', 'final: 3' ])
+      end
+    end
   end
 
   describe '#as_hash' do

--- a/spec/lib/array_spec.rb
+++ b/spec/lib/array_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 describe Array do
+  describe '#chain_map' do
+  end
+
   describe '#as_hash' do
     let(:array) { [1, 2, 3] }
     let(:keys) { %w(a b c) }


### PR DESCRIPTION
This PR adds the chain map method to array

```ruby
array = [ :a, :long_name, :sym ]
array.chain_map(:to_s, :size, :to_s)
[ '1', '9', '3' ]
```

```ruby
array = [ :a, :long_name, :sym ]
array.chain_map(:to_s, :size) { |v| "final: #{v}" }
[ 'final: 1', 'final: 9', 'final: 3' ]
```