### PR TITLE
Spec Refactor

### DIFF
--- a/spec/lib/array_spec.rb
+++ b/spec/lib/array_spec.rb
@@ -37,23 +37,23 @@ describe Array do
     let(:value) { array.map_and_find(&block) }
 
     context 'when block returns nil' do
-      let(:block) { Proc.new {} }
+      let(:block) { proc {} }
       it { expect(value).to be_nil }
     end
 
     context 'when block returns false' do
-      let(:block) { Proc.new { false } }
+      let(:block) { proc { false } }
       it { expect(value).to be_nil }
     end
 
     context 'when block returns a true evaluated value' do
-      let(:block) { Proc.new { |v| v.to_s } }
+      let(:block) { proc(&:to_s) }
 
       it { expect(value).to eq('1') }
 
       context 'but not for the first value' do
         let(:transformer) { double(:transformer) }
-        let(:block) { Proc.new { |v| transformer.transform(v) } }
+        let(:block) { proc { |v| transformer.transform(v) } }
 
         before do
           allow(transformer).to receive(:transform) do |v|

--- a/spec/lib/hash_spec.rb
+++ b/spec/lib/hash_spec.rb
@@ -239,7 +239,7 @@ describe Hash do
   end
 
   describe '#map_and_find' do
-    let(:hash) { { a: 1, b: 2, c: 3, d: 4} }
+    let(:hash) { { a: 1, b: 2, c: 3, d: 4 } }
     let(:value) { hash.map_and_find(&block) }
 
     context 'when block returns nil' do

--- a/spec/lib/hash_spec.rb
+++ b/spec/lib/hash_spec.rb
@@ -243,23 +243,23 @@ describe Hash do
     let(:value) { hash.map_and_find(&block) }
 
     context 'when block returns nil' do
-      let(:block) { Proc.new {} }
+      let(:block) { proc {} }
       it { expect(value).to be_nil }
     end
 
     context 'when block returns false' do
-      let(:block) { Proc.new { false } }
+      let(:block) { proc { false } }
       it { expect(value).to be_nil }
     end
 
     context 'when block returns a true evaluated value' do
-      let(:block) { Proc.new { |k, v| v.to_s } }
+      let(:block) { proc { |_, v| v.to_s } }
 
       it { expect(value).to eq('1') }
 
       context 'but not for the first value' do
         let(:transformer) { double(:transformer) }
-        let(:block) { Proc.new { |k, v| transformer.transform(v) } }
+        let(:block) { proc { |_, v| transformer.transform(v) } }
 
         before do
           allow(transformer).to receive(:transform) do |v|
@@ -276,7 +276,7 @@ describe Hash do
     end
 
     context 'when the block accepts one argument' do
-      let(:block) { Proc.new { |v| v } }
+      let(:block) { proc { |v| v } }
 
       it do
         expect(value).to eq([:a, 1])

--- a/spec/lib/hash_spec.rb
+++ b/spec/lib/hash_spec.rb
@@ -27,29 +27,29 @@ describe Hash do
 
   describe :sort_keys do
     it 'sorts keys as symbols' do
-      { b: 1, a: 2 }.sort_keys.should eq(a: 2, b: 1)
+      expect({ b: 1, a: 2 }.sort_keys).to eq(a: 2, b: 1)
     end
     it 'sorts keys as string' do
-      { 'b' => 1, 'a' => 2 }.sort_keys.should eq('a' => 2, 'b' => 1)
+      expect({ 'b' => 1, 'a' => 2 }.sort_keys).to eq('a' => 2, 'b' => 1)
     end
     it 'sorts keys recursively' do
-      { b: 1, a: { d: 3, c: 4 } }.sort_keys.should eq(a: { c: 4, d: 3 }, b: 1)
+      expect({ b: 1, a: { d: 3, c: 4 } }.sort_keys).to eq(a: { c: 4, d: 3 }, b: 1)
     end
     it 'sorts keys recursively when argumen is passed' do
-      { b: 1, a: { d: 3, c: 4 } }.sort_keys(recursive: true).should eq(a: { c: 4, d: 3 }, b: 1)
+      expect({ b: 1, a: { d: 3, c: 4 } }.sort_keys(recursive: true)).to eq(a: { c: 4, d: 3 }, b: 1)
     end
     it 'does not sorts keys recursively when argumen is passed' do
-      { b: 1, a: { d: 3, c: 4 } }.sort_keys(recursive: false).should eq(a: { d: 3, c: 4 }, b: 1)
+      expect({ b: 1, a: { d: 3, c: 4 } }.sort_keys(recursive: false)).to eq(a: { d: 3, c: 4 }, b: 1)
     end
     it 'sort recursevely on many levels' do
       hash = { b: 1, a: { d: 2, c: { e: 3, f: 4 } } }
       expected = { a: { c: { f: 4, e: 3 }, d: 2 }, b: 1 }
-      hash.sort_keys(recursive: true).should eq(expected)
+      expect(hash.sort_keys(recursive: true)).to eq(expected)
     end
     it 'applies to arrays as well' do
       hash = { b: 1, a: { d: 2, c: [{ e: 3, f: 4 }] } }
       expected = { a: { c: [{ f: 4, e: 3 }], d: 2 }, b: 1 }
-      hash.sort_keys(recursive: true).should eq(expected)
+      expect(hash.sort_keys(recursive: true)).to eq(expected)
     end
   end
 

--- a/spec/support/shared_examples/hash_keys_changer.rb
+++ b/spec/support/shared_examples/hash_keys_changer.rb
@@ -25,11 +25,8 @@ shared_examples 'a class with change_key method' do
 end
 
 shared_examples 'result is as expected' do
-  after do
+  it 'is as expected' do
     expect(result).to eq(expected)
-  end
-
-  it '' do
   end
 end
 

--- a/spec/support/shared_examples/hash_keys_changer.rb
+++ b/spec/support/shared_examples/hash_keys_changer.rb
@@ -24,6 +24,15 @@ shared_examples 'a class with change_key method' do
   end
 end
 
+shared_examples 'result is as expected' do
+  after do
+    expect(result).to eq(expected)
+  end
+
+  it '' do
+  end
+end
+
 shared_examples 'a mnethod that is able to change keys' do |method|
   context 'with simple level hash' do
     let(:hash) { { 'a' => 1, b: 2 } }
@@ -32,20 +41,16 @@ shared_examples 'a mnethod that is able to change keys' do |method|
       let(:result) do
         hash.public_send(method) { |k| "foo_#{k}" }
       end
-
-      it 'uses the block return as key' do
-        expect(result).to eq('foo_a' => 1, 'foo_b' => 2)
-      end
+      let(:expected) { { 'foo_a' => 1, 'foo_b' => 2 } }
+      it_behaves_like 'result is as expected'
     end
 
     context 'with symbol transformation' do
       let(:result) do
         hash.public_send(method) { |k| "foo_#{k}".to_sym }
       end
-
-      it 'uses the block return as key' do
-        expect(result).to eq(foo_a: 1, foo_b: 2)
-      end
+      let(:expected) { { foo_a: 1, foo_b: 2 } }
+      it_behaves_like 'result is as expected'
     end
   end
 
@@ -58,10 +63,7 @@ shared_examples 'a mnethod that is able to change keys' do |method|
 
     context 'when no options are given' do
       let(:options) { {} }
-
-      it 'applies the block recursively' do
-        expect(result).to eq(expected)
-      end
+      it_behaves_like 'result is as expected'
     end
 
     context 'when options are given' do
@@ -69,19 +71,13 @@ shared_examples 'a mnethod that is able to change keys' do |method|
 
       context 'with recursion' do
         let(:recursive) { true }
-
-        it 'applies the block recursively' do
-          expect(result).to eq(expected)
-        end
+        it_behaves_like 'result is as expected'
       end
 
       context 'without recursion' do
         let(:recursive) { false }
         let(:expected) { { 'foo_a' => 1, 'foo_b' =>  { c: 3, 'd' => 4 } } }
-
-        it 'does not applies the block recursively' do
-          expect(result).to eq(expected)
-        end
+        it_behaves_like 'result is as expected'
       end
     end
   end

--- a/spec/support/shared_examples/hash_keys_changer.rb
+++ b/spec/support/shared_examples/hash_keys_changer.rb
@@ -25,12 +25,28 @@ shared_examples 'a class with change_key method' do
 end
 
 shared_examples 'a mnethod that is able to change keys' do |method|
-  it 'accepts block to change the keys' do
-    expect({ 'a' => 1, b: 2 }.public_send(method) { |k| "foo_#{k}" }).to eq('foo_a' => 1, 'foo_b' => 2)
-  end
+  context 'with simple level hash' do
+    let(:hash) { { 'a' => 1, b: 2 } }
 
-  it 'accepts block to change the keys' do
-    expect({ a: 1, 'b' => 2 }.public_send(method) { |k| "foo_#{k}".to_sym }).to eq(foo_a: 1, foo_b: 2)
+    context 'with string transformation' do
+      let(:result) do
+        hash.public_send(method) { |k| "foo_#{k}" }
+      end
+
+      it 'uses the block return as key' do
+        expect(result).to eq('foo_a' => 1, 'foo_b' => 2)
+      end
+    end
+
+    context 'with symbol transformation' do
+      let(:result) do
+        hash.public_send(method) { |k| "foo_#{k}".to_sym }
+      end
+
+      it 'uses the block return as key' do
+        expect(result).to eq(foo_a: 1, foo_b: 2)
+      end
+    end
   end
 
   context 'with recursive hash' do

--- a/spec/support/shared_examples/hash_keys_changer.rb
+++ b/spec/support/shared_examples/hash_keys_changer.rb
@@ -5,7 +5,7 @@ shared_examples 'a class with change_key method' do
 
   describe :change_keys do
 
-    it_behaves_like 'a mnethod that is able to change keys', :change_keys
+    it_behaves_like 'a method that is able to change keys', :change_keys
     it 'does not affects the original hash' do
       expect do
         hash.change_keys(recursive: true) { |k| "foo_#{k}" }
@@ -14,7 +14,7 @@ shared_examples 'a class with change_key method' do
   end
 
   describe :change_keys! do
-    it_behaves_like 'a mnethod that is able to change keys', :change_keys!
+    it_behaves_like 'a method that is able to change keys', :change_keys!
 
     it 'affects the original hash' do
       expect do
@@ -33,7 +33,7 @@ shared_examples 'result is as expected' do
   end
 end
 
-shared_examples 'a mnethod that is able to change keys' do |method|
+shared_examples 'a method that is able to change keys' do |method|
   let(:foo_sym_transformation) do
     hash.public_send(method) { |k| "foo_#{k}".to_sym }
   end

--- a/spec/support/shared_examples/hash_keys_changer.rb
+++ b/spec/support/shared_examples/hash_keys_changer.rb
@@ -34,6 +34,10 @@ shared_examples 'result is as expected' do
 end
 
 shared_examples 'a mnethod that is able to change keys' do |method|
+  let(:foo_sym_transformation) do
+    hash.public_send(method) { |k| "foo_#{k}".to_sym }
+  end
+
   context 'with simple level hash' do
     let(:hash) { { 'a' => 1, b: 2 } }
 
@@ -46,9 +50,7 @@ shared_examples 'a mnethod that is able to change keys' do |method|
     end
 
     context 'with symbol transformation' do
-      let(:result) do
-        hash.public_send(method) { |k| "foo_#{k}".to_sym }
-      end
+      let(:result) { foo_sym_transformation }
       let(:expected) { { foo_a: 1, foo_b: 2 } }
       it_behaves_like 'result is as expected'
     end
@@ -87,9 +89,7 @@ shared_examples 'a mnethod that is able to change keys' do |method|
     let(:expected) do
       { foo_a: 1, foo_b: { foo_c: 2, foo_d: { foo_e: 3, foo_f: 4 } } }
     end
-    let(:result) do
-      hash.public_send(method, recursive: true) { |k| "foo_#{k}".to_sym }
-    end
+    let(:result) { foo_sym_transformation }
     it_behaves_like 'result is as expected'
   end
 end

--- a/spec/support/shared_examples/hash_keys_changer.rb
+++ b/spec/support/shared_examples/hash_keys_changer.rb
@@ -82,10 +82,15 @@ shared_examples 'a mnethod that is able to change keys' do |method|
     end
   end
 
-  it 'apply recursion on many levels' do
-    hash = { a: 1, b: { c: 2, d: { e: 3, f: 4 } } }
-    expected = { foo_a: 1, foo_b: { foo_c: 2, foo_d: { foo_e: 3, foo_f: 4 } } }
-    expect(hash.public_send(method, recursive: true) { |k| "foo_#{k}".to_sym }).to eq(expected)
+  context 'with many many levels' do
+    let(:hash) { { a: 1, b: { c: 2, d: { e: 3, f: 4 } } } }
+    let(:expected) do
+      { foo_a: 1, foo_b: { foo_c: 2, foo_d: { foo_e: 3, foo_f: 4 } } }
+    end
+    let(:result) do
+      hash.public_send(method, recursive: true) { |k| "foo_#{k}".to_sym }
+    end
+    it_behaves_like 'result is as expected'
   end
 
   it 'respect options on recursion' do

--- a/spec/support/shared_examples/hash_keys_changer.rb
+++ b/spec/support/shared_examples/hash_keys_changer.rb
@@ -92,10 +92,4 @@ shared_examples 'a mnethod that is able to change keys' do |method|
     end
     it_behaves_like 'result is as expected'
   end
-
-  it 'respect options on recursion' do
-    hash = { a: 1, b: { c: 2, d: { e: 3, f: 4 } } }
-    expected = { foo_a: 1, foo_b: { c: 2, d: { e: 3, f: 4 } } }
-    expect(hash.public_send(method, recursive: false) { |k| "foo_#{k}".to_sym }).to eq(expected)
-  end
 end

--- a/spec/support/shared_examples/hash_keys_changer.rb
+++ b/spec/support/shared_examples/hash_keys_changer.rb
@@ -34,34 +34,34 @@ end
 
 shared_examples 'a mnethod that is able to change keys' do |method|
   it 'accepts block to change the keys' do
-    { 'a' => 1, b: 2 }.public_send(method) { |k| "foo_#{k}" }.should eq('foo_a' => 1, 'foo_b' => 2)
+    expect({ 'a' => 1, b: 2 }.public_send(method) { |k| "foo_#{k}" }).to eq('foo_a' => 1, 'foo_b' => 2)
   end
 
   it 'accepts block to change the keys' do
-    { a: 1, 'b' => 2 }.public_send(method) { |k| "foo_#{k}".to_sym }.should eq(foo_a: 1, foo_b: 2)
+    expect({ a: 1, 'b' => 2 }.public_send(method) { |k| "foo_#{k}".to_sym }).to eq(foo_a: 1, foo_b: 2)
   end
 
   it 'applies the block recursively' do
-    { 'a' => 1, b:  { c: 3, d: 4 } }.public_send(method) { |k| "foo_#{k}" }.should eq('foo_a' => 1, 'foo_b' =>  { 'foo_c' => 3, 'foo_d' => 4 })
+    expect({ 'a' => 1, b:  { c: 3, d: 4 } }.public_send(method) { |k| "foo_#{k}" }).to eq('foo_a' => 1, 'foo_b' =>  { 'foo_c' => 3, 'foo_d' => 4 })
   end
 
   it 'applies the block recursively when passed in options' do
-    { 'a' => 1, b:  { c: 3, d: 4 } }.public_send(method, recursive: true) { |k| "foo_#{k}" }.should eq('foo_a' => 1, 'foo_b' =>  { 'foo_c' => 3, 'foo_d' => 4 })
+    expect({ 'a' => 1, b:  { c: 3, d: 4 } }.public_send(method, recursive: true) { |k| "foo_#{k}" }).to eq('foo_a' => 1, 'foo_b' =>  { 'foo_c' => 3, 'foo_d' => 4 })
   end
 
   it 'does not apply the block recursively when passed in options' do
-    { 'a' => 1, b:  { c: 3, 'd' => 4 } }.public_send(method, recursive: false) { |k| "foo_#{k}" }.should eq('foo_a' => 1, 'foo_b' =>  { c: 3, 'd' => 4 })
+    expect({ 'a' => 1, b:  { c: 3, 'd' => 4 } }.public_send(method, recursive: false) { |k| "foo_#{k}" }).to eq('foo_a' => 1, 'foo_b' =>  { c: 3, 'd' => 4 })
   end
 
   it 'apply recursion on many levels' do
     hash = { a: 1, b: { c: 2, d: { e: 3, f: 4 } } }
     expected = { foo_a: 1, foo_b: { foo_c: 2, foo_d: { foo_e: 3, foo_f: 4 } } }
-    hash.public_send(method, recursive: true) { |k| "foo_#{k}".to_sym }.should eq(expected)
+    expect(hash.public_send(method, recursive: true) { |k| "foo_#{k}".to_sym }).to eq(expected)
   end
 
   it 'respect options on recursion' do
     hash = { a: 1, b: { c: 2, d: { e: 3, f: 4 } } }
     expected = { foo_a: 1, foo_b: { c: 2, d: { e: 3, f: 4 } } }
-    hash.public_send(method, recursive: false) { |k| "foo_#{k}".to_sym }.should eq(expected)
+    expect(hash.public_send(method, recursive: false) { |k| "foo_#{k}".to_sym }).to eq(expected)
   end
 end

--- a/spec/support/shared_examples/hash_keys_changer.rb
+++ b/spec/support/shared_examples/hash_keys_changer.rb
@@ -25,9 +25,10 @@ shared_examples 'a class with change_key method' do
 
     it 'affects the original hash' do
       original = { 'a' => 1, b: 2, c: { d: 3, e: 4 }, f: [{ g: 5 }, { h: 6 }] }
-      not_expected = { 'a' => 1, b: 2, c: { d: 3, e: 4 }, f: [{ g: 5 }, { h: 6 }] }
-      original.change_keys!(recursive: true) { |k| "foo_#{k}" }
-      expect(original).to_not eq(not_expected)
+
+      expect do
+        original.change_keys!(recursive: true) { |k| "foo_#{k}" }
+      end.to change { original }
     end
   end
 end

--- a/spec/support/shared_examples/hash_keys_changer.rb
+++ b/spec/support/shared_examples/hash_keys_changer.rb
@@ -14,9 +14,10 @@ shared_examples 'a class with change_key method' do
 
     it 'does not affects the original hash' do
       original = { 'a' => 1, b: 2, c: { d: 3, e: 4 }, f: [{ g: 5 }, { h: 6 }] }
-      expected = { 'a' => 1, b: 2, c: { d: 3, e: 4 }, f: [{ g: 5 }, { h: 6 }] }
-      original.change_keys(recursive: true) { |k| "foo_#{k}" }
-      expect(original).to eq(expected)
+
+      expect do
+        original.change_keys(recursive: true) { |k| "foo_#{k}" }
+      end.not_to change { original }
     end
   end
 

--- a/spec/support/shared_examples/hash_keys_changer.rb
+++ b/spec/support/shared_examples/hash_keys_changer.rb
@@ -2,15 +2,6 @@ shared_examples 'a class with change_key method' do
   describe :change_keys do
     it_behaves_like 'a mnethod that is able to change keys', :change_keys
 
-    it 'should call change_keys!' do
-      original = { 'a' => 1, b: 2, c: { d: 3, e: 4 } }
-      copy = { 'a' => 1, b: 2, c: { d: 3, e: 4 } }
-
-      expect(original).to receive(:deep_dup).and_return(copy)
-      expect(copy).to receive(:change_keys!)
-      original.change_keys(recursive: true) { |k| "foo_#{k}" }
-    end
-
     it 'does not affects the original hash' do
       original = { 'a' => 1, b: 2, c: { d: 3, e: 4 }, f: [{ g: 5 }, { h: 6 }] }
 

--- a/spec/support/shared_examples/hash_keys_changer.rb
+++ b/spec/support/shared_examples/hash_keys_changer.rb
@@ -1,13 +1,15 @@
 shared_examples 'a class with change_key method' do
+  let(:hash) do
+    { 'a' => 1, b: 2, c: { d: 3, e: 4 }, f: [{ g: 5 }, { h: 6 }] }
+  end
+
   describe :change_keys do
+
     it_behaves_like 'a mnethod that is able to change keys', :change_keys
-
     it 'does not affects the original hash' do
-      original = { 'a' => 1, b: 2, c: { d: 3, e: 4 }, f: [{ g: 5 }, { h: 6 }] }
-
       expect do
-        original.change_keys(recursive: true) { |k| "foo_#{k}" }
-      end.not_to change { original }
+        hash.change_keys(recursive: true) { |k| "foo_#{k}" }
+      end.not_to change { hash }
     end
   end
 
@@ -15,11 +17,9 @@ shared_examples 'a class with change_key method' do
     it_behaves_like 'a mnethod that is able to change keys', :change_keys!
 
     it 'affects the original hash' do
-      original = { 'a' => 1, b: 2, c: { d: 3, e: 4 }, f: [{ g: 5 }, { h: 6 }] }
-
       expect do
-        original.change_keys!(recursive: true) { |k| "foo_#{k}" }
-      end.to change { original }
+        hash.change_keys!(recursive: true) { |k| "foo_#{k}" }
+      end.to change { hash }
     end
   end
 end

--- a/spec/support/shared_examples/keys_appender.rb
+++ b/spec/support/shared_examples/keys_appender.rb
@@ -1,43 +1,43 @@
 shared_examples 'a class with append_keys method' do
   describe :prepend_to_keys do
     it 'accepts block to change the keys' do
-      { a: 1, 'b' => 2 }.prepend_to_keys('foo_').should eq(foo_a: 1, 'foo_b' => 2)
+      expect({ a: 1, 'b' => 2 }.prepend_to_keys('foo_')).to eq(foo_a: 1, 'foo_b' => 2)
     end
     it 'applies the block recursively' do
-      { 'a' => 1, b:  { c: 3, 'd' => 4 } }.prepend_to_keys('foo_').should eq('foo_a' => 1, foo_b:  { foo_c: 3, 'foo_d' => 4 })
+      expect({ 'a' => 1, b:  { c: 3, 'd' => 4 } }.prepend_to_keys('foo_')).to eq('foo_a' => 1, foo_b:  { foo_c: 3, 'foo_d' => 4 })
     end
     it 'changes type when type option is passed' do
-      { 'a' => 1, b: 2 }.prepend_to_keys('foo_', type: :string).should eq('foo_a' => 1, 'foo_b' => 2)
+      expect({ 'a' => 1, b: 2 }.prepend_to_keys('foo_', type: :string)).to eq('foo_a' => 1, 'foo_b' => 2)
     end
     it 'changes type when type option is passed' do
-      { 'a' => 1, b: 2 }.prepend_to_keys('foo_', type: :symbol).should eq(foo_a: 1, foo_b: 2)
+      expect({ 'a' => 1, b: 2 }.prepend_to_keys('foo_', type: :symbol)).to eq(foo_a: 1, foo_b: 2)
     end
     it 'keep type when type option is passed as keep' do
-      { 'a' => 1, b: 2 }.prepend_to_keys('foo_', type: :keep).should eq('foo_a' => 1, foo_b: 2)
+      expect({ 'a' => 1, b: 2 }.prepend_to_keys('foo_', type: :keep)).to eq('foo_a' => 1, foo_b: 2)
     end
     it 'applies to array as well' do
-      { 'a' => 1, b: [{ c: 2 }, { d: 3 }] }.prepend_to_keys('foo_', type: :keep).should eq('foo_a' => 1, foo_b: [{ foo_c: 2 }, { foo_d: 3 }])
+      expect({ 'a' => 1, b: [{ c: 2 }, { d: 3 }] }.prepend_to_keys('foo_', type: :keep)).to eq('foo_a' => 1, foo_b: [{ foo_c: 2 }, { foo_d: 3 }])
     end
   end
 
   describe :append_to_keys do
     it 'accepts block to change the keys' do
-      { a: 1, 'b' => 2 }.append_to_keys('_bar').should eq(a_bar: 1, 'b_bar' => 2)
+      expect({ a: 1, 'b' => 2 }.append_to_keys('_bar')).to eq(a_bar: 1, 'b_bar' => 2)
     end
     it 'applies the block recursively' do
-      { 'a' => 1, b:  { c: 3, 'd' => 4 } }.append_to_keys('_bar').should eq('a_bar' => 1, b_bar:  { c_bar: 3, 'd_bar' => 4 })
+      expect({ 'a' => 1, b:  { c: 3, 'd' => 4 } }.append_to_keys('_bar')).to eq('a_bar' => 1, b_bar:  { c_bar: 3, 'd_bar' => 4 })
     end
     it 'changes type when type option is passed' do
-      { 'a' => 1, b: 2 }.append_to_keys('_bar', type: :string).should eq('a_bar' => 1, 'b_bar' => 2)
+      expect({ 'a' => 1, b: 2 }.append_to_keys('_bar', type: :string)).to eq('a_bar' => 1, 'b_bar' => 2)
     end
     it 'changes type when type option is passed' do
-      { 'a' => 1, b: 2 }.append_to_keys('_bar', type: :symbol).should eq(a_bar: 1, b_bar: 2)
+      expect({ 'a' => 1, b: 2 }.append_to_keys('_bar', type: :symbol)).to eq(a_bar: 1, b_bar: 2)
     end
     it 'keep type when type option is passed as keep' do
-      { 'a' => 1, b: 2 }.append_to_keys('_bar', type: :keep).should eq('a_bar' => 1, b_bar: 2)
+      expect({ 'a' => 1, b: 2 }.append_to_keys('_bar', type: :keep)).to eq('a_bar' => 1, b_bar: 2)
     end
     it 'applies to array as well' do
-      { 'a' => 1, b: [{ c: 2 }, { d: 3 }] }.append_to_keys('_bar', type: :keep).should eq('a_bar' => 1, b_bar: [{ c_bar: 2 }, { d_bar: 3 }])
+      expect({ 'a' => 1, b: [{ c: 2 }, { d: 3 }] }.append_to_keys('_bar', type: :keep)).to eq('a_bar' => 1, b_bar: [{ c_bar: 2 }, { d_bar: 3 }])
     end
   end
 end

--- a/spec/support/shared_examples/value_changer.rb
+++ b/spec/support/shared_examples/value_changer.rb
@@ -33,31 +33,31 @@ end
 
 shared_examples 'a method that change the hash values' do |method|
   it 'updates values of hash' do
-    subject.public_send(method) { |value| value + 1 }.should eq(a: 2, b: 3, c: { d: 4, e: 5 })
+    expect(subject.public_send(method) { |value| value + 1 }).to eq(a: 2, b: 3, c: { d: 4, e: 5 })
   end
 
   it 'works recursively when parameter is passed' do
-    subject.change_values(recursive: true) { |value| value + 1 }.should eq(a: 2, b: 3, c: { d: 4, e: 5 })
+    expect(subject.change_values(recursive: true) { |value| value + 1 }).to eq(a: 2, b: 3, c: { d: 4, e: 5 })
   end
 
   it 'does not work recursively when parameter is passed as false' do
-    subject.change_values(recursive: false) { |value| value + 1 }.should eq(a: 2, b: 3, c: { d: 3, e: 4 })
+    expect(subject.change_values(recursive: false) { |value| value + 1 }).to eq(a: 2, b: 3, c: { d: 3, e: 4 })
   end
 
   it 'does not ignore hash when option is passed' do
-    subject.change_values(skip_inner: false) { |value| value.is_a?(Hash) ? 10 + value.size : value + 1 }.should eq(a: 2, b: 3, c: 12)
+    expect(subject.change_values(skip_inner: false) { |value| value.is_a?(Hash) ? 10 + value.size : value + 1 }).to eq(a: 2, b: 3, c: 12)
   end
 
   it 'ignore hash and work recursively when option is passed' do
-    subject.change_values(skip_inner: false) { |value| value.is_a?(Hash) ? value : value + 1 }.should eq(a: 2, b: 3, c: { d: 4, e: 5 })
+    expect(subject.change_values(skip_inner: false) { |value| value.is_a?(Hash) ? value : value + 1 }).to eq(a: 2, b: 3, c: { d: 4, e: 5 })
   end
 
   it 'ignore hash and does not work recursively when option is passed' do
-    subject.change_values(skip_inner: false, recursive: false) { |value| value.is_a?(Hash) ? value : value + 1 }.should eq(a: 2, b: 3, c: { d: 3, e: 4 })
+    expect(subject.change_values(skip_inner: false, recursive: false) { |value| value.is_a?(Hash) ? value : value + 1 }).to eq(a: 2, b: 3, c: { d: 3, e: 4 })
   end
 
   it 'applies to arrays as well' do
     subject = { a: 1, b: 2, c: [{ d: 3 }, { e: 4 }] }
-    subject.public_send(method) { |value| value + 1 }.should eq(a: 2, b: 3, c: [{ d: 4 }, { e: 5 }])
+    expect(subject.public_send(method) { |value| value + 1 }).to eq(a: 2, b: 3, c: [{ d: 4 }, { e: 5 }])
   end
 end


### PR DESCRIPTION
This PR refactor the specs to use newest format

- [x] Use ```expect().to``` instead of ```.should```
- [x] Refatoração de hash_keys_changer.rb